### PR TITLE
改行コードをSRCとDESTで別々にする

### DIFF
--- a/src/document_composer/config.py
+++ b/src/document_composer/config.py
@@ -18,7 +18,8 @@ from document_composer.constants import (
     HEADER_DISTANCE_MM,
     FOOTER_DISTANCE_MM,
     ENCODING,
-    NEWLINE_CODE,
+    NEWLINE_CODE_SRC,
+    NEWLINE_CODE_DEST,
     CONFIG_FILE_PATH,
     NewlineCode,
     NewlineChar
@@ -53,7 +54,8 @@ class Config:
         header_distance_mm (float): ヘッダーの幅。ミリ単位。
         footer_distance_mm (float): フッターの幅。ミリ単位。
         encoding (str): 文字エンコーディング方式。
-        newline_code (str): 改行コード。
+        newline_code_src (NewlineCode): 入力ファイル改行コード。
+        newline_code_dest (NewlineCode): 出力ファイル改行コード。
     """
     ignorants: list[pathlib.Path]
     dest_root_file_nickname: str
@@ -70,7 +72,8 @@ class Config:
     header_distance_mm: float
     footer_distance_mm: float
     encoding: str
-    newline_code: NewlineCode
+    newline_code_src: NewlineCode
+    newline_code_dest: NewlineCode
 
     @property
     def ignorants_as_str(self) -> pathlib.Path:
@@ -82,13 +85,22 @@ class Config:
         return [ig.resolve() for ig in self.ignorants]
 
     @property
-    def newline_char(self) -> NewlineChar:
-        """改行コードを改行文字として取得。
+    def newline_char_src(self) -> NewlineChar:
+        """入力ファイルの改行コードを改行文字として取得。
 
         Returns:
             NewlineChar: 改行文字。
         """
-        return get_newline_char(self.newline_code)
+        return get_newline_char(self.newline_code_src)
+
+    @property
+    def newline_char_dest(self) -> NewlineChar:
+        """出力ファイルの改行コードを改行文字として取得。
+
+        Returns:
+            NewlineChar: 改行文字。
+        """
+        return get_newline_char(self.newline_code_dest)
 
     @classmethod
     def from_yml(cls, config_file_path: str = CONFIG_FILE_PATH) -> 'Config':
@@ -132,7 +144,8 @@ class Config:
             header_distance_mm=d.get("header_distance_mm", HEADER_DISTANCE_MM),
             footer_distance_mm=d.get("footer_distance_mm", FOOTER_DISTANCE_MM),
             encoding=d.get("encoding", ENCODING),
-            newline_code=d.get("newline_code", NEWLINE_CODE),
+            newline_code_src=d.get("newline_code_src", NEWLINE_CODE_SRC),
+            newline_code_dest=d.get("newline_code_dest", NEWLINE_CODE_DEST),
         )
 
     def __repr__(self):
@@ -155,4 +168,5 @@ class Config:
             + f"header_distance_mm={self.header_distance_mm}, " \
             + f"footer_distance_mm={self.footer_distance_mm}, " \
             + f"encodingf={self.encoding}, " \
-            + f"newline_code={self.newline_code}"
+            + f"newline_code_src={self.newline_code_src}" \
+            + f"newline_code_dest={self.newline_code_dest}"

--- a/src/document_composer/config.yml
+++ b/src/document_composer/config.yml
@@ -31,4 +31,5 @@ footer_distance_mm: 19.0
 
 # 一般規則
 encoding: utf-8
-newline_code: "LF"
+newline_code_src: "LF"
+newline_code_dest: "LF"

--- a/src/document_composer/constants.py
+++ b/src/document_composer/constants.py
@@ -36,7 +36,11 @@ BOTTOM_MARGIN_MM: float = 19.0
 HEADER_DISTANCE_MM: float = 19.0
 FOOTER_DISTANCE_MM: float = 19.0
 ENCODING: str = "utf-8"
-NEWLINE_CODE: str = "LF"
+NEWLINE_CODE_SRC: NewlineCode = "LF"
+NEWLINE_CODE_DEST: NewlineCode = "LF"
+
+# システムファイルの改行コード
+NEWLINE_CODE_SYSTEM: NewlineCode = "LF"
 
 # GUIデータ保存先
 SCREEN_FILE_PATH: str = "./.user.yml"

--- a/src/document_composer/gui/root_screen.py
+++ b/src/document_composer/gui/root_screen.py
@@ -33,7 +33,7 @@ from document_composer.constants import (
     Extension,
     SCREEN_FILE_PATH,
     ENCODING,
-    NEWLINE_CODE,
+    NEWLINE_CODE_SYSTEM,
     SRC_ROOT_DIR_PATH,
     DEST_ROOT_DIR_PATH,
     CONFIG_FILE_PATH,
@@ -85,7 +85,7 @@ class RootScreenModel:
             RootScreenModel: インスタンス。
         """
         if pathlib.Path(model_file_path).exists():
-            with open(model_file_path, mode="r", encoding=ENCODING, newline=get_newline_char(NEWLINE_CODE)) as f:
+            with open(model_file_path, mode="r", encoding=ENCODING, newline=get_newline_char(NEWLINE_CODE_SYSTEM)) as f:
                 d = yaml.load(f, Loader=ScreenLoader)
                 if d is None:
                     d = {}
@@ -106,7 +106,7 @@ class RootScreenModel:
         Args:
             model_file_path (str): スクリーンモデルファイルまでのパス。
         """
-        with open(model_file_path, mode="w", encoding=ENCODING, newline=get_newline_char(NEWLINE_CODE)) as f:
+        with open(model_file_path, mode="w", encoding=ENCODING, newline=get_newline_char(NEWLINE_CODE_SYSTEM)) as f:
             yaml.dump(self.to_dict(), f, Dumper=ScreenDumper, sort_keys=False)
 
     def to_dict(self) -> dict:

--- a/src/document_composer/main.py
+++ b/src/document_composer/main.py
@@ -7,6 +7,7 @@ import logging
 import logging.config
 import pathlib
 from document_composer.constants import (
+    ENCODING,
     SRC_ROOT_DIR_PATH,
     DEST_ROOT_DIR_PATH,
     CONFIG_FILE_PATH,
@@ -33,7 +34,7 @@ def initialize_logging():
     if not logging_dir_path.exists():
         logging_dir_path.mkdir()
     # ロギング構成ファイルから読みだしてロガー作成
-    with open(LOGGING_CONFIG_FILE_PATH) as f:
+    with open(LOGGING_CONFIG_FILE_PATH, encoding=ENCODING) as f:
         d = yaml.load(f, Loader=LoggingLoader)
     logging.config.dictConfig(d)
 

--- a/src/document_composer/models/composable/docx.py
+++ b/src/document_composer/models/composable/docx.py
@@ -6,6 +6,12 @@ from docx.shared import Pt, Mm
 from document_composer.models.composable.base import Composable
 from document_composer.constants import Extension
 from document_composer.config import Config
+from document_composer.util import (
+    integrate_newline_code,
+    join_lines,
+    split_to_lines,
+    strip_empty_line
+)
 
 
 @dataclasses.dataclass
@@ -72,14 +78,10 @@ class Docx(Composable):
         doc = Document(str(self.file_path))
         lines = [p.text for p in doc.paragraphs]
         if lines:
-            # 先頭・末尾に存在する空行を削除する
-            start = 0
-            end = len(lines)
-            while start < end and lines[start].strip() == "":
-                start += 1
-            while end > start and lines[end - 1].strip() == "":
-                end -= 1
-            lines = lines[start:end]
+            content = join_lines(lines)  # システム用の改行コードで一度結合
+            content = integrate_newline_code(content)  # 改行コード統一
+            content = strip_empty_line(content)  # 先頭と末尾の空行をトリミング
+            lines = split_to_lines(content)  # システム用の改行コードで行のリストに戻す
             self.append_lines(lines)
 
     def write_file(self):

--- a/src/document_composer/models/composable/txt.py
+++ b/src/document_composer/models/composable/txt.py
@@ -4,6 +4,12 @@ import pathlib
 from document_composer.models.composable.base import Composable
 from document_composer.constants import Extension
 from document_composer.config import Config
+from document_composer.util import (
+    integrate_newline_code,
+    join_lines,
+    split_to_lines,
+    strip_empty_line
+)
 
 
 @dataclasses.dataclass
@@ -67,11 +73,15 @@ class Txt(Composable):
 
     def read_file(self):
         """ファイルを読み込む。"""
-        with open(str(self.file_path), mode="r", encoding=self.config.encoding, newline=self.config.newline_char) as f:
-            lines = f.read().strip(self.config.newline_char).split(self.config.newline_char)  # ファイルの先頭と末尾にある改行はトリム
+        with open(str(self.file_path), mode="r", encoding=self.config.encoding, newline=self.config.newline_char_src) as f:
+            content = f.read()
+            content = integrate_newline_code(content)  # 改行コード統一
+            content = strip_empty_line(content)  # 先頭と末尾の空行をトリミング
+            lines = split_to_lines(content)  # システム用の改行コードで分割
             self.append_lines(lines)
 
     def write_file(self):
         """ファイルを書き込み。"""
-        with open(str(self.file_path), mode="w", encoding=self.config.encoding, newline=self.config.newline_char) as f:
-            f.write(self.config.newline_char.join(self.get_lines()))
+        with open(str(self.file_path), mode="w", encoding=self.config.encoding, newline=self.config.newline_char_dest) as f:
+            content = join_lines(self.get_lines())  # システム用の改行コードで結合
+            f.write(content)

--- a/src/document_composer/util.py
+++ b/src/document_composer/util.py
@@ -1,8 +1,12 @@
 """汎用便利モジュール。"""
-from document_composer.constants import (NewlineCode, NewlineChar)
+from document_composer.constants import (
+    NEWLINE_CODE_SYSTEM,
+    NewlineCode,
+    NewlineChar
+)
 
 
-def get_newline_type(newline_char: NewlineChar) -> NewlineCode:
+def get_newline_code(newline_char: NewlineChar) -> NewlineCode:
     """改行コードを取得する。
 
     Args:
@@ -40,3 +44,67 @@ def get_newline_char(newline_code: NewlineCode) -> NewlineChar:
             return "\r"
         case _:
             return "\r\n"
+
+
+def join_lines(lines: list[str], newline_code: NewlineCode = NEWLINE_CODE_SYSTEM) -> str:
+    """行を結合する。
+
+    Args:
+        strings (list[str]): 結合対象の行リスト。
+        newline_code (NewlineCode): 結合に用いる改行コード。
+
+    Returns:
+        str: 1行に結合した文字列。
+    """
+    return get_newline_char(newline_code).join(lines)
+
+
+def split_to_lines(content: str, newline_code: NewlineCode = NEWLINE_CODE_SYSTEM) -> list[str]:
+    """文字列を行に分割する。
+
+    Args:
+        content (str): 分割対象の文字列。
+        newline_code (NewlineCode): 分割に用いる改行コード。
+
+    Returns:
+        list[str]: 文字列を分割した行リスト。
+    """
+    return content.split(get_newline_char(newline_code))
+
+
+def strip_empty_line(content: str, newline_code: NewlineCode = NEWLINE_CODE_SYSTEM) -> str:
+    """文字列の先頭と末尾の空行をストリップ(トリム)する。
+
+    Args:
+        content (str): ストリップ対象の文字列。
+        newline_code (NewlineCode): 空行扱いする文字コード。
+
+    Returns:
+        str: ストリップ後の文字列。
+    """
+    return content.strip(get_newline_char(newline_code))
+
+
+def integrate_newline_code(
+    string: str,
+    newline_code_integrated: NewlineCode = NEWLINE_CODE_SYSTEM
+) -> str:
+    """文字列に含まれる改行文字列を統一する。
+
+    Args:
+        string: サニタイズ対象の文字列。
+        newline_code_integrated: 統一先の改行コード。
+
+    Returns:
+        str: 改行コード統一後の文字列。
+    """
+    match(newline_code_integrated):
+        case "LF":
+            string = string.replace("\r\n", "\n").replace("\r", "\n")
+        case "CR":
+            string = string.replace("\r\n", "\n").replace("\n", "\r")
+        case "CRLF":
+            string = string.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n")
+        case _:
+            pass
+    return string


### PR DESCRIPTION
issue: #17

ファイル読み込みの改行コード周りの全体的な調整、`Txt`と`Docx`でのサニタイズ周りの調整も含む。